### PR TITLE
Fix Android button size 

### DIFF
--- a/lib/MobileStoreButton.js
+++ b/lib/MobileStoreButton.js
@@ -43,7 +43,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 var imageLinks = {
   ios: 'https://linkmaker.itunes.apple.com/images/badges/en-us/badge_appstore-lrg.svg',
-  android: 'https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'
+  android: 'https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg'
 };
 
 var MobileStoreButton =

--- a/src/MobileStoreButton.jsx
+++ b/src/MobileStoreButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const imageLinks = {
   ios: 'https://linkmaker.itunes.apple.com/images/badges/en-us/badge_appstore-lrg.svg',
-  android: 'https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png',
+  android: 'https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg',
 };
 
 class MobileStoreButton extends React.Component {


### PR DESCRIPTION
- [x] Change the google play button image `URL` so it can fit in the container 

As you can see in the image below the `google play` button is smaller than the `app store` button and this is because the image used for the google play button has extra space, so what I did is I changed the URL with a new one that has no extra space.

![image](https://user-images.githubusercontent.com/58111243/225677458-d2ef8d95-e472-47fa-a56d-a27365db3675.png)
![image](https://user-images.githubusercontent.com/58111243/225677887-5718091e-9350-4033-980f-bbe426c74c2a.png)

  